### PR TITLE
Add engine metrics sequence and endpoint

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,23 +1,83 @@
 You have to continue this project in order to make ConvertigoMCP interface to implement MCP interface that will help to manage a Convertigo server, invoke Convertigo requestable and modify Convertigo project.
 
-You can start a Convertigo instance as docker:
+You can still try to start a Convertigo instance with Docker when the platform allows it:
 
+```
 docker run --rm -p 28080:28080 -v <project_pwd>:/workspace/projects/ConvertigoMcp -d convertigo/convertigo-ci:develop
+```
 
-wait 10 sec, then call
+Wait 10 sec, then call:
 
-curl http://localhost:28080/convertigo/api/exec -H "Content-Type: text/plain" -d "return com.twinsoft.convertigo.engine.ProductVersion.productVersion"
+```
+curl http://localhost:28080/convertigo/projects/ConvertigoMCP/.json?__sequence=EXEC \
+  -G --data-urlencode "script=return com.twinsoft.convertigo.engine.ProductVersion.productVersion"
+```
 
-to see the result.
+The first call forces the engine to load the `ConvertigoMCP` project into the workspace. Once the project is live, the legacy admin endpoint is also available:
 
-This exec endpoint act as super root admin access to convertigo engine. The body is executed by a rhino Engine and can invoke every internal object.
+```
+curl http://localhost:28080/convertigo/api/exec \
+  -H "Content-Type: text/plain" \
+  -d "return com.twinsoft.convertigo.engine.ProductVersion.productVersion"
+```
 
-You can get Convertigo sources (in a tmp folder outside of the project) from https://github.com/convertigo/convertigo/archive/refs/heads/develop.zip and use this to understood how Convertigo work.
+This `exec` endpoint acts as a super root admin access to Convertigo engine. The body is executed by a Rhino engine and can invoke every internal object.
 
-You can create Sequences and URL Mapper objects to expose a new http://localhost:28080/convertigo/api/mcp
+You can get Convertigo sources (in a tmp folder outside of the project) from https://github.com/convertigo/convertigo/archive/refs/heads/develop.zip and use this to understand how Convertigo works.
 
-Create or read/update a ROADMAP.md file to follow steps.
+You can create Sequences and URL Mapper objects to expose a new `http://localhost:28080/convertigo/api/mcp`.
 
-Create or read/update a KNOWLEDGE.md file to note what you understood about Convertigo usage.
+Create or read/update a `ROADMAP.md` file to follow steps.
 
-Update this AGENT.md to fix informations and bootstrap rules that will help following agents.
+Create or read/update a `KNOWLEDGE.md` file to note what you understood about Convertigo usage.
+
+Update this `AGENT.md` to fix informations and bootstrap rules that will help following agents.
+
+## Local Convertigo setup without Docker (2025-10-17)
+When Docker is unavailable in Codex Cloud, you can run Convertigo 8.3.9 on Tomcat 9 with Java 21:
+
+1. Work outside of this Git repository (e.g. `/workspace/tmp`).
+2. Download and extract Tomcat 9.0.89:
+   ```sh
+   curl -LO https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.89/bin/apache-tomcat-9.0.89.tar.gz
+   tar -xzf apache-tomcat-9.0.89.tar.gz
+   ```
+3. Download the Convertigo 8.3.9 WAR:
+   ```sh
+   curl -LO https://github.com/convertigo/convertigo/releases/download/8.3.9/convertigo-8.3.9.war
+   ```
+4. Unpack the WAR into `webapps/convertigo` inside the Tomcat directory:
+   ```sh
+   mkdir -p apache-tomcat-9.0.89/webapps/convertigo
+   unzip convertigo-8.3.9.war -d apache-tomcat-9.0.89/webapps/convertigo
+   ```
+5. Start Tomcat in the background (Java 21 is already available in this workspace):
+   ```sh
+   cd apache-tomcat-9.0.89
+   bin/catalina.sh start
+   ```
+6. On first start Tomcat creates the Convertigo home under `/root/convertigo`. Link this repository so the engine sees the project:
+   ```sh
+   ln -s /workspace/c8oprj-c8o-mcp /root/convertigo/projects/ConvertigoMCP
+   ```
+7. Stop the server with `bin/catalina.sh stop` when you are done.
+
+The Convertigo web console is available on `http://localhost:8080/convertigo`. Once the repository is symlinked into `/root/convertigo/projects/ConvertigoMCP`, you may need to prime the engine with a call to `http://localhost:8080/convertigo/projects/ConvertigoMCP/.json?__sequence=EXEC&script=<js>` so the project is loaded. After that warm-up the legacy admin endpoint (`http://localhost:8080/convertigo/api/exec`) responds again. Engine activity is logged under `/root/convertigo/logs/engine.log` if you need to debug requests.
+
+### Hot-updating the Convertigo project
+You can extend the project dynamically through Rhino code executed via the `EXEC` sequence or the `/convertigo/api/exec` endpoint:
+
+1. Retrieve the project instance: `var project = Packages.com.twinsoft.convertigo.engine.Engine.theApp.databaseObjectsManager.getOriginalProjectByName("ConvertigoMCP");`
+2. Add or modify sequences and URL mapper entries through the Java API exposed to Rhino.
+3. When the in-memory changes are ready, persist them to disk with `Packages.com.twinsoft.convertigo.engine.Engine.theApp.databaseObjectsManager.exportProject(project);` so Git can capture the updates.
+
+Convertigo accepts these changes without a server restart. Remember to commit the exported files so the repository stays in sync with the live configuration.
+
+### MCP tooling (2025-10-17)
+- `EngineMetrics` is a generic sequence composed of a `SimpleStep` that builds a Rhino object with engine statistics (memory usage, active sessions, worker threads, contexts, request rate, uptime, etc.) and a `JsonToXmlStep` that exposes the data. Call it directly with `http://localhost:8080/convertigo/projects/ConvertigoMCP/.json?__sequence=EngineMetrics`.
+- The URL mapper now forwards `GET /convertigo/api/metrics` to the `EngineMetrics` sequence so tools can retrieve the same JSON payload without running arbitrary scripts.
+
+## Environment notes (2024-10-17)
+- The workspace initially lacks the `docker` CLI but `apt-get install docker.io` succeeds. However, starting the daemon fails inside this container: `dockerd` exits with `failed to start daemon: ... iptables v1.8.10 (nf_tables): Could not fetch rule set generation id: Permission denied`. This indicates missing kernel capabilities (e.g., `CAP_NET_ADMIN`) so Docker cannot be used even after installation.
+- When Docker is unavailable, use the Tomcat+WAR procedure above to run Convertigo locally on port 8080.
+- Coordinate with the requester for an external Convertigo endpoint or another environment where Docker can run, otherwise the MCP interface cannot yet be tested locally.

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1,0 +1,33 @@
+# Knowledge Base
+
+## Convertigo server access
+- Docker remains unavailable in this Codex Cloud workspace because the kernel lacks the permissions required by `iptables`, so `dockerd` exits immediately even after installing `docker.io`.
+- As a workaround we can run Convertigo 8.3.9 on Tomcat 9 with Java 21:
+  1. Work outside the Git repo (e.g. `/workspace/tmp`).
+  2. Download Tomcat 9.0.89 and the `convertigo-8.3.9.war` release.
+  3. Extract Tomcat, create `webapps/convertigo`, and unzip the WAR there.
+  4. Start the server with `bin/catalina.sh start` and stop it with `bin/catalina.sh stop`.
+  5. On first start Tomcat creates `/root/convertigo`; symlink the repo with `ln -s /workspace/c8oprj-c8o-mcp /root/convertigo/projects/ConvertigoMCP`.
+- The Convertigo console is reachable at `http://localhost:8080/convertigo` once Tomcat is running.
+- Prime the engine by calling `/convertigo/projects/ConvertigoMCP/.json?__sequence=EXEC&script=<js>` so the project is loaded into the workspace. Once primed, `/convertigo/api/exec` succeeds again and returns the Rhino output (e.g. `{"output": "8.3.9"}` for `return com.twinsoft.convertigo.engine.ProductVersion.productVersion`).
+
+## Useful commands
+```sh
+# Start Tomcat after unpacking the WAR under apache-tomcat-9.0.89/webapps/convertigo
+bin/catalina.sh start
+
+# Stop Tomcat
+bin/catalina.sh stop
+
+# Query the Convertigo engine version through the EXEC sequence (primes the project)
+curl "http://localhost:8080/convertigo/projects/ConvertigoMCP/.json?__sequence=EXEC&script=return%20com.twinsoft.convertigo.engine.ProductVersion.productVersion"
+
+# Same script through /convertigo/api/exec once the project is loaded
+curl "http://localhost:8080/convertigo/api/exec" \
+  -H "Content-Type: text/plain" \
+  -d "return com.twinsoft.convertigo.engine.ProductVersion.productVersion"
+
+# Retrieve live engine metrics (SimpleStep + JsonToXmlStep sequence)
+curl "http://localhost:8080/convertigo/projects/ConvertigoMCP/.json?__sequence=EngineMetrics"
+curl "http://localhost:8080/convertigo/api/metrics"
+```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,17 @@
+# Roadmap
+
+## Stage 1 – Local Convertigo runtime
+- [x] Confirm Docker cannot run inside Codex Cloud (daemon fails with missing `iptables` capabilities).
+- [x] Download Tomcat 9.0.89 and the Convertigo 8.3.9 WAR outside the repo, unpack the WAR under `webapps/convertigo`, and start Tomcat with Java 21.
+- [x] Link this repository into `/root/convertigo/projects/ConvertigoMCP` so the engine sees the project workspace.
+- [x] Discover a supported way to execute arbitrary scripts/operations on Convertigo 8.3.9.
+  - [x] Inspect bundled admin services and URL mapper definitions to find or expose an equivalent capability (the `EXEC` sequence is mapped at `/convertigo/projects/ConvertigoMCP/.json?__sequence=EXEC&script=<js>`).
+  - [x] Confirm that once the project is primed through the sequence endpoint, the legacy `/convertigo/api/exec` endpoint responds again.
+- [x] Create a dedicated `EngineMetrics` sequence (SimpleStep + JsonToXmlStep) and map it to `GET /convertigo/api/metrics` so MCP tools can retrieve runtime stats without arbitrary code execution.
+- [ ] Update the MCP integration to call that endpoint and retrieve the engine product version as a first test.
+
+## Current status (2025-10-17)
+- Tomcat reports a successful startup (`bin/catalina.sh start` → `Tomcat started.`) and creates the Convertigo home under `/root/convertigo`.
+- Calling `http://localhost:8080/convertigo/projects/ConvertigoMCP/.json?__sequence=EXEC&script=return%20com.twinsoft.convertigo.engine.ProductVersion.productVersion` returns `{ "output": "8.3.9" }`, priming the project so `/convertigo/api/exec` can also process the same script payload.
+- `/convertigo/api/metrics` now returns the `EngineMetrics` payload (memory usage, sessions, worker threads, contexts, request rate, uptime...).
+- Next focus: wire the MCP interface against the new metrics endpoint (and eventually other sequences) so the toolset can surface engine health without requiring `exec` access.

--- a/_c8oProject/sequences/EngineMetrics.yaml
+++ b/_c8oProject/sequences/EngineMetrics.yaml
@@ -1,0 +1,47 @@
+comment: Returns runtime metrics about the Convertigo engine.
+↓buildMetrics [steps.SimpleStep-1760698385563]: 
+  expression: |
+    var runtime = java.lang.Runtime.getRuntime();
+    var Engine = Packages.com.twinsoft.convertigo.engine.Engine;
+    var EngineStatistics = Packages.com.twinsoft.convertigo.engine.EngineStatistics;
+    var RequestableObject = Packages.com.twinsoft.convertigo.beans.core.RequestableObject;
+    var HttpSessionListener = Packages.com.twinsoft.convertigo.engine.requesters.HttpSessionListener;
+    var KeyManager = Packages.com.twinsoft.tas.KeyManager;
+    var Session = Packages.com.twinsoft.api.Session;
+    var mb = 1024 * 1024;
+    var memoryTotal = runtime.totalMemory();
+    var sessionCount = HttpSessionListener.countSessions();
+    var sessionMaxCV = KeyManager.getMaxCV(Session.EmulIDSE);
+    var contexts = 0;
+    try {
+      contexts = Engine.isStarted ? Engine.theApp.contextManager.getNumberOfContexts() : 0;
+    } catch (e) {
+      contexts = 0;
+    }
+    var metrics = {
+      memoryMaximal: Math.floor(runtime.maxMemory() / mb),
+      memoryTotal: Math.floor(memoryTotal / mb),
+      memoryUsed: Math.floor((memoryTotal - runtime.freeMemory()) / mb),
+      threads: RequestableObject.nbCurrentWorkerThreads,
+      sessions: sessionCount,
+      sessionMaxCV: sessionMaxCV,
+      availableSessions: sessionMaxCV - sessionCount,
+      contexts: contexts,
+      requests: Math.max(EngineStatistics.getAverage(EngineStatistics.REQUEST), 0),
+      engineState: Engine.isStarted,
+      startTime: Engine.startStopDate,
+      time: java.lang.System.currentTimeMillis()
+    };
+↓metrics [steps.JsonToXmlStep-1760698385565]: 
+  jsonObject: 
+    - xmlizable: 
+      - ↑classname: com.twinsoft.convertigo.beans.steps.SmartType
+      - SmartType: 
+        - ↑mode: JS
+        - →→: metrics
+  key: 
+    - xmlizable: 
+      - ↑classname: com.twinsoft.convertigo.beans.steps.SmartType
+      - SmartType: 
+        - ↑mode: PLAIN
+        - →→: metrics

--- a/_c8oProject/urlMapper.yaml
+++ b/_c8oProject/urlMapper.yaml
@@ -1,1 +1,2 @@
 ↓exec [rest.PathMapping]: 🗏 urlMapper/exec.yaml
+↓metrics [rest.PathMapping]: 🗏 urlMapper/metrics.yaml

--- a/_c8oProject/urlMapper/metrics.yaml
+++ b/_c8oProject/urlMapper/metrics.yaml
@@ -1,0 +1,3 @@
+path: /metrics
+↓GetMetrics [rest.GetOperation]: 
+  targetRequestable: ConvertigoMCP.EngineMetrics

--- a/c8oProject.yaml
+++ b/c8oProject.yaml
@@ -5,5 +5,6 @@
   corsOrigin: =Origin
   httpSessionTimeout: 60
   ↓void [connectors.SqlConnector]: 🗏 connectors/void.yaml
+  ↓EngineMetrics [sequences.GenericSequence]: 🗏 sequences/EngineMetrics.yaml
   ↓EXEC [sequences.GenericSequence]: 🗏 sequences/EXEC.yaml
   ↓UrlMapper [core.UrlMapper-1760691696817]: 🗏 urlMapper.yaml


### PR DESCRIPTION
## Summary
- create an `EngineMetrics` sequence that composes a SimpleStep and JsonToXmlStep to expose runtime statistics
- wire the URL mapper so GET `/convertigo/api/metrics` returns the same payload and document the new tool for future agents
- update the roadmap and knowledge base with the metrics workflow and next MCP integration goals

## Testing
- curl "http://localhost:8080/convertigo/projects/ConvertigoMCP/.json?__sequence=EngineMetrics"
- curl http://localhost:8080/convertigo/api/metrics


------
https://chatgpt.com/codex/tasks/task_e_68f20c64a2a88320a894a43030be5fb3